### PR TITLE
Reflection replaces constants for injector

### DIFF
--- a/src/hex/annotation/AnnotationReplaceBuilder.hx
+++ b/src/hex/annotation/AnnotationReplaceBuilder.hx
@@ -26,15 +26,18 @@ class AnnotationReplaceBuilder
 		}
 		
 		var fields = Context.getBuildFields();
-		fields.map(function (f)
-		{
-			f.meta.map(processMetadata);
-		});
-		
+		buildFields(fields);
 		return fields;
 	}
 	
-	static function processMetadata(m:MetadataEntry):Void
+	public static function buildFields(fields:Array<Field>):Void
+	{
+		fields
+			.flatMap(function (f) return f.meta)
+			.map(processMetadata);
+	}
+	
+	public static function processMetadata(m:MetadataEntry):Void
 	{
 		m.params = m.params.flatMap(function(p){
 			switch(p.expr)
@@ -65,7 +68,7 @@ class AnnotationReplaceBuilder
 				}
 				var path = getPath(e);
 				return processConst(getId(path, str), processForeignConst.bind(path, str, expression.pos), expression);
-			case EConst(CIdent(i)) if (i != "null"):
+			case EConst(CIdent(i)) if (i != "null" && i != "true" && i != "false"):
 				return processConst(getLocalId(i), processLocalConst.bind(i, expression.pos), expression);
 			case EConst(c):
 				return expression;
@@ -103,7 +106,7 @@ class AnnotationReplaceBuilder
 			else
 			{
 				staticsCache.set(id, originalExpression);
-				logger.warn('Constant "$id" not found');//, originalExpression.pos
+				Context.warning('"$id" is not a constant value and won\'t be replaced', originalExpression.pos);
 			}
 		}
 		return staticsCache.get(id);
@@ -120,6 +123,7 @@ class AnnotationReplaceBuilder
 				case _: null;
 			}
 		}
+		
 		return null;
 	}
 	

--- a/src/hex/di/annotation/FastAnnotationReader.hx
+++ b/src/hex/di/annotation/FastAnnotationReader.hx
@@ -3,10 +3,12 @@ package hex.di.annotation;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Expr.Field;
+import hex.annotation.AnnotationReplaceBuilder;
 import hex.di.reflect.ClassDescription;
 import hex.error.PrivateConstructorException;
 import hex.reflect.ClassReflectionData;
 import hex.util.ArrayUtil;
+using Lambda;
 
 /**
  * ...
@@ -43,6 +45,12 @@ class FastAnnotationReader
 		var reflectionData:Null<ExprOf<ClassDescription>>;
 		
 		var annotationFilter = [ "Inject", "PostConstruct", "Optional", "PreDestroy" ];
+		
+		// use AnnotationReplaceBuilder to to process the metadata but only the ones that we care about
+		fields
+			.flatMap(function (f) return f.meta)
+			.filter(function (m) return annotationFilter.indexOf(m.name) != -1)
+			.map(AnnotationReplaceBuilder.processMetadata);
 		
 		if ( hasBeenBuilt )
 		{

--- a/test/hex/annotation/MockMetadataClass.hx
+++ b/test/hex/annotation/MockMetadataClass.hx
@@ -156,8 +156,6 @@ class MockMetadataClassWithInjectorContainerWithLocalVars implements IInjectorCo
 	
 }
 
-/*
-// Doesn't compile
 class MockMetadataClassWithInjectorContainerDifferentOrder implements IAnnotationReplace implements IInjectorContainer 
 {
 	public function new() 
@@ -169,4 +167,3 @@ class MockMetadataClassWithInjectorContainerDifferentOrder implements IAnnotatio
 	public var injected_optional:String;
 	
 }
-*/


### PR DESCRIPTION
FastAnnotationReader is using AnnotationReplaceBuilder to automatically replace constants in injector metadata